### PR TITLE
修复多分片消息导出、解密目录自动识别及 Python 3.9 兼容性问题

### DIFF
--- a/export_contact.py
+++ b/export_contact.py
@@ -14,10 +14,12 @@ import csv
 import hashlib
 import json
 import os
+import re
 import sqlite3
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 _SCRIPT_DIR = Path(__file__).parent
 _CONFIG_PATH = _SCRIPT_DIR / 'config.json'
@@ -30,22 +32,70 @@ def load_config() -> dict:
     return {}
 
 
+def _looks_like_db_storage(path: Path) -> bool:
+    return (
+        (path / 'contact' / 'contact.db').exists() and
+        (path / 'message' / 'message_0.db').exists()
+    )
+
+
+def _resolve_db_dir(base: Path) -> Optional[Path]:
+    """兼容直接传 db_storage 目录，或传 decrypt_db.py 输出根目录。"""
+    if _looks_like_db_storage(base):
+        return base
+
+    candidates = []
+    for pattern in ('wxid_*/db_storage', '*/db_storage'):
+        for candidate in base.glob(pattern):
+            if not candidate.is_dir() or not _looks_like_db_storage(candidate):
+                continue
+            msg_db = candidate / 'message' / 'message_0.db'
+            mtime = msg_db.stat().st_mtime if msg_db.exists() else 0
+            candidates.append((mtime, candidate))
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    chosen = candidates[0][1]
+    print(f"[*] 自动选择解密数据库目录：{chosen}")
+    return chosen
+
+
 def get_db_dir() -> Path:
     cfg = load_config()
     db_dir = cfg.get('decrypted_db_dir', '')
     if db_dir:
         p = Path(os.path.expanduser(db_dir))
-        if p.exists():
-            return p
+        resolved = _resolve_db_dir(p) if p.exists() else None
+        if resolved is not None:
+            return resolved
     default = Path.home() / 'Documents/wechat-db-decrypt-macos/decrypted'
-    if default.exists():
-        return default
+    resolved = _resolve_db_dir(default) if default.exists() else None
+    if resolved is not None:
+        return resolved
     print("❌ 找不到解密数据库目录。请检查 config.json 中的 decrypted_db_dir 路径。")
     sys.exit(1)
 
 
 def md5(text: str) -> str:
     return hashlib.md5(text.encode()).hexdigest()
+
+
+def get_message_dbs(db_dir: Path) -> list[Path]:
+    """返回所有已解密的 message_N.db，按编号排序。"""
+    msg_dir = db_dir / 'message'
+    if not msg_dir.exists():
+        return []
+
+    paths = []
+    for path in msg_dir.glob('message_*.db'):
+        m = re.fullmatch(r'message_(\d+)\.db', path.name)
+        if m:
+            paths.append((int(m.group(1)), path))
+
+    paths.sort(key=lambda item: item[0])
+    return [path for _, path in paths]
 
 
 def list_contacts(db_dir: Path):
@@ -87,7 +137,11 @@ def get_self_wxid(db_dir: Path) -> str:
             return candidates[0]
 
     # 方法2：从 Name2Id 表中找唯一的 wxid_ 账号（排除联系人）
-    msg_db = db_dir / 'message' / 'message_0.db'
+    msg_dbs = get_message_dbs(db_dir)
+    if not msg_dbs:
+        return None
+
+    msg_db = msg_dbs[0]
     contact_db = db_dir / 'contact' / 'contact.db'
     conn = sqlite3.connect(msg_db)
     rows = conn.execute("SELECT user_name FROM Name2Id").fetchall()
@@ -124,25 +178,38 @@ def get_sender_rowids(msg_db: Path, self_wxid: str, contact_wxid: str):
 def export_messages(db_dir: Path, contact_wxid: str, contact_name: str,
                     self_wxid: str, output_path: Path):
     table = f"Msg_{md5(contact_wxid)}"
-    msg_db = db_dir / 'message' / 'message_0.db'
-
-    conn = sqlite3.connect(msg_db)
-    tables = [r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")]
-    if table not in tables:
-        print(f"❌ 找不到消息表 {table}，可能没有与此联系人的消息记录。")
-        conn.close()
+    msg_dbs = get_message_dbs(db_dir)
+    if not msg_dbs:
+        print("❌ 找不到已解密的 message_N.db 文件。")
         sys.exit(1)
 
-    self_id, _ = get_sender_rowids(msg_db, self_wxid, contact_wxid)
+    merged_rows = []
+    matched_dbs = []
+    for msg_db in msg_dbs:
+        conn = sqlite3.connect(msg_db)
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        if table not in tables:
+            conn.close()
+            continue
 
-    rows = conn.execute(
-        f"SELECT create_time, real_sender_id, local_type, message_content "
-        f"FROM {table} ORDER BY create_time ASC"
-    ).fetchall()
-    conn.close()
+        self_id, _ = get_sender_rowids(msg_db, self_wxid, contact_wxid)
+        rows = conn.execute(
+            f"SELECT create_time, real_sender_id, local_type, message_content "
+            f"FROM {table} ORDER BY create_time ASC"
+        ).fetchall()
+        conn.close()
 
-    msg_count = len(rows)
-    print(f"[*] 找到 {msg_count} 条消息")
+        matched_dbs.append(msg_db.name)
+        merged_rows.extend((create_time, sender_id, local_type, content, self_id)
+                           for create_time, sender_id, local_type, content in rows)
+
+    if not merged_rows:
+        print(f"❌ 找不到消息表 {table}，可能没有与此联系人的消息记录。")
+        sys.exit(1)
+
+    merged_rows.sort(key=lambda row: row[0])
+    msg_count = len(merged_rows)
+    print(f"[*] 找到 {msg_count} 条消息（来自 {', '.join(matched_dbs)}）")
 
     try:
         import zstd
@@ -164,20 +231,44 @@ def export_messages(db_dir: Path, contact_wxid: str, contact_name: str,
             return raw.decode('utf-8', errors='replace')
         return str(raw)
 
+    json_records = []
+
     with open(output_path, 'w', newline='', encoding='utf-8-sig') as f:
         writer = csv.writer(f)
         writer.writerow(['timestamp', 'datetime', 'sender', 'is_sender', 'type', 'content'])
-        for create_time, sender_id, local_type, content in rows:
+        for create_time, sender_id, local_type, content, self_id in merged_rows:
             dt = datetime.fromtimestamp(create_time).strftime('%Y-%m-%d %H:%M:%S')
             is_self = 1 if sender_id == self_id else 0
             sender_name = '我' if is_self else contact_name
-            writer.writerow([create_time, dt, sender_name, is_self, local_type, decode_content(content)])
+            text = decode_content(content)
+            writer.writerow([create_time, dt, sender_name, is_self, local_type, text])
+            json_records.append({
+                'timestamp': int(create_time),
+                'datetime': dt,
+                'sender': sender_name,
+                'is_sender': int(is_self),
+                'type': int(local_type),
+                'content': text,
+            })
+
+    json_path = output_path.with_suffix('.json')
+    with open(json_path, 'w', encoding='utf-8') as f:
+        json.dump({
+            'format': 'wechat_chat_export_v1',
+            'contact_wxid': contact_wxid,
+            'contact_name': contact_name,
+            'self_wxid': self_wxid,
+            'message_count': msg_count,
+            'source_databases': matched_dbs,
+            'messages': json_records,
+        }, f, ensure_ascii=False, indent=2)
 
     print(f"EXPORT_PATH:{output_path}")
+    print(f"JSON_PATH:{json_path}")
     return msg_count
 
 
-def get_self_nick(db_dir: Path, self_wxid: str) -> str | None:
+def get_self_nick(db_dir: Path, self_wxid: str) -> Optional[str]:
     """尝试从 contact.db 或微信文件目录获取自己的昵称"""
     # 方法1：contact.db 里可能有自己的记录
     try:
@@ -202,7 +293,7 @@ def get_self_nick(db_dir: Path, self_wxid: str) -> str | None:
     return None
 
 
-def get_avatar_path(wxid: str, db_dir: Path | None = None) -> str | None:
+def get_avatar_path(wxid: str, db_dir: Optional[Path] = None) -> Optional[str]:
     """搜索头像：先查文件系统缓存，再从 head_image.db 提取，失败返回 None。
     若从数据库读取，将图片写入临时文件并返回其路径。"""
     import glob as _glob

--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ import base64
 import json
 import os
 import sys
+from typing import Optional
 
 import data_loader
 from data_loader import _replace_wechat_emoji
@@ -58,7 +59,7 @@ def _load_meta(csv_path: str) -> dict:
     return {}
 
 
-def _avatar_b64(path: str | None) -> str | None:
+def _avatar_b64(path: Optional[str]) -> Optional[str]:
     """读取头像文件并转为 base64 data URI，失败返回 None"""
     if not path or not os.path.exists(path):
         return None

--- a/report.py
+++ b/report.py
@@ -5,6 +5,7 @@ report.py — 生成最终 HTML 报告（双栏对比 + 热力图版）
 import json as _json
 import os
 from datetime import datetime
+from typing import Optional
 
 
 # ── CSS ──────────────────────────────────────────────────────────────────────
@@ -638,7 +639,7 @@ function initHeatmap(selfData, partnerData, hasPartner) {
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
-def _av(name: str, data: str | None, size: int = 38, cls: str = 'av-self') -> str:
+def _av(name: str, data: Optional[str], size: int = 38, cls: str = 'av-self') -> str:
     initial = name[:1] if name else '?'
     inner = (f'<img src="{data}" alt="{initial}" onerror="this.style.display=\'none\';'
              f'this.parentNode.textContent=\'{initial}\'">' if data else initial)
@@ -646,12 +647,12 @@ def _av(name: str, data: str | None, size: int = 38, cls: str = 'av-self') -> st
             f'style="width:{size}px;height:{size}px;font-size:{size//2}px">{inner}</div>')
 
 
-def _pill(name: str, data: str | None, partner: bool = False) -> str:
+def _pill(name: str, data: Optional[str], partner: bool = False) -> str:
     av = _av(name, data, size=38, cls='av-partner' if partner else 'av-self')
     return f'<div class="person-pill">{av}<span class="pill-name">{name}</span></div>'
 
 
-def _tag(name: str, data: str | None, partner: bool = False) -> str:
+def _tag(name: str, data: Optional[str], partner: bool = False) -> str:
     cls = 'tag-partner' if partner else 'tag-self'
     initial = name[:1] if name else '?'
     inner = (f'<img src="{data}" alt="{initial}" onerror="this.style.display=\'none\';'
@@ -663,7 +664,7 @@ def _tag(name: str, data: str | None, partner: bool = False) -> str:
 # ── Section builders ──────────────────────────────────────────────────────────
 
 def _butterfly_big5(b5s: dict, b5p: dict,
-                    sn: str, pn: str, sa: str | None, pa: str | None) -> str:
+                    sn: str, pn: str, sa: Optional[str], pa: Optional[str]) -> str:
     labels = [
         ('openness',          '开放性', 'Openness'),
         ('conscientiousness', '尽责性', 'Conscientiousness'),
@@ -740,7 +741,7 @@ def _single_big5(big5: dict) -> str:
 
 
 def _mbti_panel(mbti: dict, partner: bool = False,
-                name: str = '?', av: str | None = None) -> str:
+                name: str = '?', av: Optional[str] = None) -> str:
     mtype = mbti.get('type', '??')
     conf, note = mbti.get('confidence', '低'), mbti.get('note', '')
     dims = mbti.get('dims', {})
@@ -767,7 +768,7 @@ def _mbti_panel(mbti: dict, partner: bool = False,
 
 
 def _style_panel(style: dict, partner: bool = False,
-                 name: str = '?', av: str | None = None) -> str:
+                 name: str = '?', av: Optional[str] = None) -> str:
     one_line  = style.get('one_line', '')
     summary   = style.get('summary', '')
     strengths = style.get('strengths', [])
@@ -787,8 +788,8 @@ def _style_panel(style: dict, partner: bool = False,
     </div>'''
 
 
-def _heatmap_html(stats_self: dict, stats_partner: dict | None,
-                  sn: str, pn: str, sa: str | None, pa: str | None) -> str:
+def _heatmap_html(stats_self: dict, stats_partner: Optional[dict],
+                  sn: str, pn: str, sa: Optional[str], pa: Optional[str]) -> str:
     """生成热力图 HTML + 内嵌 JS"""
     daily_self = {str(k): int(v) for k, v in stats_self['daily'].items()}
 
@@ -851,8 +852,8 @@ def generate(stats: dict, personality: dict, output_dir: str,
              partner_personality: dict = None,
              self_name: str = '我',
              partner_name: str = '对方',
-             self_avatar_data: str | None = None,
-             partner_avatar_data: str | None = None,
+             self_avatar_data: Optional[str] = None,
+             partner_avatar_data: Optional[str] = None,
              has_pair_wordcloud: bool = False) -> str:
 
     dr = stats['date_range']

--- a/visualizer.py
+++ b/visualizer.py
@@ -4,6 +4,7 @@ visualizer.py — 生成所有可视化图表（姜饼棕白风格）
 
 import os
 from collections import Counter
+from typing import Optional
 
 import matplotlib
 import matplotlib.font_manager as fm
@@ -25,7 +26,7 @@ TEAL_DARK    = '#4A7B6F'
 TEAL_MID     = '#6FAA9C'
 
 # 词云字体文件路径（需要文件路径，不能只用字体名称）
-_WC_FONT_PATH: str | None = None
+_WC_FONT_PATH: Optional[str] = None
 
 # 候选字体文件路径
 _FONT_FILE_CANDIDATES = [
@@ -40,7 +41,7 @@ _FONT_FILE_CANDIDATES = [
 
 
 # ── 字体检测 ──────────────────────────────────────────────────────────────────
-def setup_font() -> str | None:
+def setup_font() -> Optional[str]:
     global _WC_FONT_PATH
     candidates = [
         'PingFang SC', 'Heiti SC', 'STHeiti', 'STSong',


### PR DESCRIPTION
## 背景

在基于本项目做本地微信聊天分析时，遇到了几类会直接影响可用性的问题：

1. 当 `config.json` 中的 `decrypted_db_dir` 指向 `decrypt_db.py` 产出的 `decrypted/` 根目录时，`export_contact.py` 不能自动定位真实的 `wxid_*/db_storage` 目录。
2. `export_contact.py` 只读取 `message_0.db`，当聊天历史已经分片到多个 `message_N.db` 时，导出的消息会明显不完整。
3. 部分文件使用了 `str | None` 这类 Python 3.10+ 语法，导致在 Python 3.9 环境下脚本直接无法运行。

这些问题叠加后，会让“联系人导出”和“后续分析”在真实数据量较大的场景里很难顺利走通。

## 复现方式

### 问题 1：无法自动识别解密数据库目录

1. 使用 `decrypt_db.py` 将数据库解密到默认输出目录 `~/Documents/wechat-db-decrypt-macos/decrypted/`
2. 在 `config.json` 中将 `decrypted_db_dir` 配置为这个输出根目录
3. 执行 `python3 export_contact.py --list-contacts`

预期：脚本能自动找到实际可用的 `wxid_*/db_storage`

实际：脚本只把配置路径当作最终目录使用，无法继续定位真实数据库目录

### 问题 2：只导出最新分片，历史消息缺失

1. 某个联系人聊天跨越多个 `message_N.db`
2. 执行 `python3 export_contact.py --contact <联系人>`

预期：导出应覆盖所有已解密分片中的该联系人消息

实际：只读取 `message_0.db`，更早历史不会进入导出结果

### 问题 3：Python 3.9 直接语法报错

在 Python 3.9 环境运行以下任一脚本：

- `main.py`
- `report.py`
- `visualizer.py`
- `export_contact.py`

会因为 `str | None` / `dict | None` 之类类型写法而直接报语法错误。

## 修改内容

### 1. 自动解析真实的解密数据库目录

在 `export_contact.py` 中增加目录解析逻辑：

- 兼容直接传入 `db_storage` 目录
- 兼容传入 `decrypt_db.py` 输出的 `decrypted/` 根目录
- 当存在多个候选目录时，优先选择最近活跃的数据库目录

### 2. 合并读取所有 `message_N.db`

在 `export_contact.py` 中新增 `get_message_dbs()`：

- 自动发现所有已解密的 `message_*.db`
- 按编号排序后依次读取
- 只要分片中存在对应消息表，就把结果合并导出
- 最终按消息时间统一排序，避免分片切换带来的顺序问题

### 3. 同步输出 JSON 导出结果

在原有 CSV 导出基础上，同时输出一个结构化 JSON 文件，便于后续程序继续做分析，而不必再次回到数据库层。

### 4. 修复 Python 3.9 兼容性

将相关文件中的 PEP 604 类型写法改为 `typing.Optional[...]`，覆盖：

- `main.py`
- `report.py`
- `visualizer.py`
- `export_contact.py`

## 影响范围

这次修改主要影响两类场景：

1. 项目首次接入本地解密产物时，目录识别更稳，不再要求用户手工把路径精确到 `db_storage`
2. 聊天历史较长、数据库已分片时，导出结果更完整，更适合作为后续分析输入

同时保留了现有使用方式，不改变既有 CLI 参数。

## 验证

本地已做以下验证：

```bash
python3 -m py_compile export_contact.py main.py report.py visualizer.py
```

验证结果：通过。

另外，基于多分片数据场景验证后，联系人导出已经可以正确合并多个 `message_N.db` 的消息结果。

## 说明

本 PR 只提交通用修复，不包含任何个人聊天内容、数据库样本、联系人标识或本地生成的分析结果文件。
